### PR TITLE
Enhancement: Add IntWrapper Class

### DIFF
--- a/IntWrapper.cpp
+++ b/IntWrapper.cpp
@@ -1,0 +1,36 @@
+/*
+ * IntWrapper.cpp
+ *
+ *  Created on: Nov 9, 2019
+ *      Author: ramy
+ */
+
+#include "IntWrapper.h"
+
+bool operator < ( const IntWrapper &lhs, const uint16_t &rhs)
+{
+	return lhs.builtInInt < rhs;
+}
+bool operator > ( const IntWrapper &lhs, const uint16_t &rhs)
+{
+	return lhs.builtInInt > rhs;
+}
+
+bool operator == ( const IntWrapper &lhs, const uint16_t &rhs)
+{
+	return lhs.builtInInt == rhs;
+}
+
+uint16_t operator / (const IntWrapper &lhs, const uint16_t &rhs)
+{
+	return lhs.builtInInt / rhs; // integer division
+}
+uint16_t operator % (const IntWrapper &lhs, const uint16_t &rhs)
+{
+	return lhs.builtInInt % rhs;
+}
+void IntWrapper::operator = ( const uint16_t &rhs)
+{
+	 builtInInt = rhs;
+}
+

--- a/IntWrapper.h
+++ b/IntWrapper.h
@@ -1,0 +1,32 @@
+/*
+ * IntWrapper.h
+ *
+ *  Created on: Nov 9, 2019
+ *      Author: ramy
+ */
+
+#ifndef INTWRAPPER_H_
+#define INTWRAPPER_H_
+#include "common.h"
+
+// Wrapper Class for built-in unsigned short integer
+class IntWrapper{
+public:
+	 explicit IntWrapper(uint16_t builtInInt): builtInInt{builtInInt}{}
+	void operator =( const uint16_t &rhs);
+
+	friend bool operator < ( const IntWrapper &lhs, const uint16_t &rhs);
+	friend bool operator > ( const IntWrapper &lhs, const uint16_t &rhs);
+	friend bool operator == ( const IntWrapper &lhs, const uint16_t &rhs);
+	friend uint16_t operator %( const IntWrapper &lhs, const uint16_t &rhs);
+	friend uint16_t operator /( const IntWrapper &lhs, const uint16_t &rhs);
+	friend uint16_t operator %=( const IntWrapper &lhs, const uint16_t &rhs);
+
+
+private:
+	uint16_t builtInInt;
+};
+
+
+
+#endif /* INTWRAPPER_H_ */

--- a/application.cpp
+++ b/application.cpp
@@ -86,7 +86,7 @@ int main() {
 					cout << "zero has no equivalent Roman Numeral\n";
 				}
 				else{
-					DecimalInst.convert(decInput,result);
+					DecimalInst.convert((IntWrapper)decInput,result);
 				}
 				if (result != "") (cout << "Equivalent Decimal Number is: "<< result);
 			}
@@ -127,7 +127,6 @@ void runTestCases()
 	cout << "\n================== Test Group 4: Decimal Troublesome Values Conversion =================\n\n";
 	testTroubleSomeDecimalValues();
 	cout << "\n================== Test Group 5: Decimal Normal Values Conversion ======================\n\n";
-
 	testNormalDecimalValue();
 
 }
@@ -268,27 +267,24 @@ void testTroubleSomeDecimalValues()
 	RETURN_STATE retState;
 
 	// Double/Float Conversion not allowed, return Roman Numeral should be empty
-	retState = decInst.convert(23.5, result);
-	cout << "TEST CASE 4.1: [Decimal Conversion] input [23.5] result[] empty           ? "<< (result=="") << endl;
-	cout << "               return state is RETURN_STATE::ERR_FLOAT_NOT_ALLOWED        ? "
-		 << (retState == RETURN_STATE::ERR_FLOAT_NOT_ALLOWED) << endl << endl;
+	retState = decInst.convert(IntWrapper(23.5), result); // Compilation Error
 
 	// Passing wrong inputs like strings or a character results in compilation errors.
 
 	// Negative Numbers
-	retState = decInst.convert(-24, result);
+	retState = decInst.convert(static_cast<IntWrapper>(-24), result);
 	cout << "TEST CASE 4.2: [Decimal Conversion] input [-24]  result[] empty           ? "<< (result=="") << endl;
 	cout << "               return state is RETURN_STATE::ERR_NEGATIVE_NUM_NOT_ALLOWED ? "
 		 << (retState == RETURN_STATE::ERR_NEGATIVE_NUM_NOT_ALLOWED) << endl << endl;
 
 	// Zero Decimal
-	retState = decInst.convert(0, result);
+	retState = decInst.convert(static_cast<IntWrapper>(0), result);
 	cout << "TEST CASE 4.3: [Decimal Conversion] input [0]    result[] empty           ? "<< (result=="") << endl;
 	cout << "               return state is RETURN_STATE::ERR_ZERO_NOT_ALLOWED         ? "
 		<< (retState == RETURN_STATE::ERR_ZERO_NOT_ALLOWED) << endl << endl;
 
 	// Greater than 10000 Decimal
-	retState = decInst.convert(10001, result);
+	retState = decInst.convert(IntWrapper(10001), result);
 	cout << "TEST CASE 4.4: [Decimal Conversion] input [0]    result[] empty           ? "<< (result=="") << endl;
 	cout << "               return state is RETURN_STATE::ERR_DECIMAL_OVER_MAX         ? "
 		<< (retState == RETURN_STATE::ERR_DECIMAL_OVER_MAX) << endl << endl;
@@ -301,48 +297,48 @@ void testNormalDecimalValue()
 	RETURN_STATE retState;
 
 	// Test Normal Values
-	retState = decInst.convert(15, result);
+	retState = decInst.convert(IntWrapper(15), result);
 	cout << "TEST CASE 5.1: [Decimal Conversion] input [15]    result[XV]                ? "<< (result=="XV") << endl;
 	cout << "               return state is RETURN_STATE::OK                             ? "
 		<< (retState == RETURN_STATE::OK) << endl << endl;
 
 	// Test Normal Values
-	retState = decInst.convert(23, result);
+	retState = decInst.convert(IntWrapper(23), result);
 	cout << "TEST CASE 5.2: [Decimal Conversion] input [23]    result[XXIII]             ? "<< (result=="XXIII") << endl;
 	cout << "               return state is RETURN_STATE::OK                             ? "
 		<< (retState == RETURN_STATE::OK) << endl << endl;
 
 	// Test Normal Values
-	retState = decInst.convert(45, result);
+	retState = decInst.convert(IntWrapper(45), result);
 	cout << "TEST CASE 5.3: [Decimal Conversion] input [45]    result[XLV]               ? "<< (result=="XLV") << endl;
 	cout << "               return state is RETURN_STATE::OK                             ? "
 		<< (retState == RETURN_STATE::OK) << endl << endl;
 
 	// Test Normal Values
-	retState = decInst.convert(234, result);
+	retState = decInst.convert(IntWrapper(234), result);
 	cout << "TEST CASE 5.4: [Decimal Conversion] input [234]   result[CCXXXIV]           ? "<< (result=="CCXXXIV") << endl;
 	cout << "               return state is RETURN_STATE::OK                             ? "
 		<< (retState == RETURN_STATE::OK) << endl << endl;
 
 	// Test Normal Values
-	retState = decInst.convert(1467, result);
+	retState = decInst.convert(IntWrapper(1467), result);
 	cout << "TEST CASE 5.5: [Decimal Conversion] input [1467]  result[MCDLXVII]          ? "<< (result=="MCDLXVII") << endl;
 	cout << "               return state is RETURN_STATE::OK                             ? "
 		<< (retState == RETURN_STATE::OK) << endl << endl;
 
 	// Test Normal Values
-	retState = decInst.convert(2765, result);
+	retState = decInst.convert(IntWrapper(2765), result);
 	cout << "TEST CASE 5.6: [Decimal Conversion] input [2765]  result[MMDCCLXV]          ? "<< (result=="MMDCCLXV") << endl;
 	cout << "               return state is RETURN_STATE::OK                             ? "
 		<< (retState == RETURN_STATE::OK) << endl << endl;
 
 	// Test Normal Values
-	retState = decInst.convert(3575, result);
+	retState = decInst.convert(IntWrapper(3575), result);
 	cout << "TEST CASE 5.7: [Decimal Conversion] input [2765]  result[MMMDLXXV]          ? "<< (result=="MMMDLXXV") << endl;
 	cout << "               return state is RETURN_STATE::OK                             ? "
 		<< (retState == RETURN_STATE::OK) << endl << endl;
 
-	retState = decInst.convert(9899, result);
+	retState = decInst.convert(IntWrapper(9899), result);
 	cout << "TEST CASE 5.7: [Decimal Conversion] input [9899]  result[MMMMMMMMMDCCCXCIX] ? "<< (result=="MMMMMMMMMDCCCXCIX") << endl;
 	cout << "               return state is RETURN_STATE::OK                             ? "
 		<< (retState == RETURN_STATE::OK) << endl << endl;

--- a/common.h
+++ b/common.h
@@ -26,4 +26,10 @@ enum class RETURN_STATE
 
 };
 
+
+//uint16_t operator %= (const  IntWrapper &lhs, const uint16_t &rhs)
+//{
+//	lhs.builtInInt = lhs.builtInInt % rhs; // integer division
+//	return lhs.builtInInt;
+//}
 #endif /* COMMON_H_ */

--- a/decimal_convert.cpp
+++ b/decimal_convert.cpp
@@ -7,51 +7,40 @@ DecimalNumerals::DecimalNumerals():
 {
 }
 
-RETURN_STATE DecimalNumerals::convert(const double &rIn, string &rOut)
+RETURN_STATE DecimalNumerals::convert(const IntWrapper &rIn, string &rOut)
 {
 	RETURN_STATE retVal = RETURN_STATE::OK;
 	// each time initialize the output string, caught from Test Group 5 [TC 5.1 to TC 5.7]
 	rOut="";
 	// As a result of Test Case 4.2
-	if ( (uint16_t)rIn == 0){
+	if ( rIn == 0){
 		cout << "Zero cannot be converted to Roman\n";
 		rOut = "";
 		retVal = RETURN_STATE::ERR_ZERO_NOT_ALLOWED;
 	}
-	else if ( (uint16_t)rIn < 0){
+	else if ( rIn < 0){
 		cout << "Negative numbers not allowed\n";
 		rOut = "";
 		retVal = RETURN_STATE::ERR_NEGATIVE_NUM_NOT_ALLOWED;
 	}
-	else if (!(isUint(rIn))){
-		cout << "Float numbers not allowed\n";
-		retVal = RETURN_STATE::ERR_FLOAT_NOT_ALLOWED;
-		rOut = "";
-	}
+
 	else if (rIn > 10000U){
 		cout << "Greater than the Max [10000]\n";
 		retVal = RETURN_STATE::ERR_DECIMAL_OVER_MAX;
 		rOut = "";
 	}
 	else{
-	    uint16_t  num = rIn;
+
+
+		IntWrapper  num = rIn;
 		for ( uint8_t i = 12; num > 0; i--){
 			uint8_t div = num/romanSymDecVals[i];
-			num %= romanSymDecVals[i];
+			num = num % romanSymDecVals[i];
 			while(div--){
 				rOut += romanSymbols[i];
 			}
 		}
 	}
 
-	return retVal;
-}
-
-// As a result of Test Group 4 [TC 4.1]
-bool DecimalNumerals::isUint(const double d)
-{
-	bool retVal = false;
-	if (d-(uint16_t)d == 0)
-	     retVal = true;
 	return retVal;
 }

--- a/decimal_convert.h
+++ b/decimal_convert.h
@@ -5,7 +5,7 @@
 #include <string>
 #include <map>
 #include "common.h"
-
+#include "IntWrapper.h"
 class DecimalNumerals
 {
 public:
@@ -20,7 +20,7 @@ public:
 	 *param[out] rOut reference to the ouput resulted Roman numeral to be stored in
 	 *return     RETURN_STATE enum of the error code or OK if no errors.
 	*/
-	RETURN_STATE convert(const double &rIn, std::string &rOut);
+	RETURN_STATE convert(const IntWrapper &rIn, std::string &rOut);
 
 private:
 	// check if passed number is a real dobule

--- a/roman_convert.h
+++ b/roman_convert.h
@@ -18,6 +18,7 @@ public:
 	*/
 	RETURN_STATE convert(const std::string &rIn, uint16_t &rOut);
 	~RomanNumerals(){}
+
 private:
 	/* @param[in] romanNum: reference to the input Roman numeral string
 	 * return 	RETURN_STATE can be OK if no error or a certain error code


### PR DESCRIPTION
- Replace double with IntWrapper in RomanNumeral::convert()
- Overload all integer arithmetic operations in IntWrapper class.
- provide its constructor as "explicit" to prohibit conversion from double to Int, which is the main reason this class is added. 